### PR TITLE
Fix Supabase saving and show previous set info

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,12 @@ import { ProgressCharts } from './components/ProgressCharts';
 import { Navigation } from './components/Navigation';
 import { workoutProgram, recoveryDay } from './data/workoutProgram';
 import { Dumbbell } from 'lucide-react';
+import { useAuth } from './hooks/useAuth';
 
 function App() {
   const [currentView, setCurrentView] = useState('schedule');
   const [selectedWorkoutDay, setSelectedWorkoutDay] = useState<number | null>(null);
+  useAuth();
 
   const handleSelectDay = (dayIndex: number) => {
     setSelectedWorkoutDay(dayIndex);

--- a/src/components/ExerciseTracker.tsx
+++ b/src/components/ExerciseTracker.tsx
@@ -20,7 +20,7 @@ export function ExerciseTracker({
   workoutDay,
   workoutSessionId
 }: ExerciseTrackerProps) {
-  const { saveExerciseSet, getWorkoutExerciseId } = useWorkoutData();
+  const { saveExerciseSet, getWorkoutExerciseId, getLastExerciseStats } = useWorkoutData();
 
   // All hooks must be called before any conditional logic
   const [sets, setSets] = useState<WorkoutSet[]>([]);
@@ -28,6 +28,7 @@ export function ExerciseTracker({
   const [restTimer, setRestTimer] = useState(0);
   const [isResting, setIsResting] = useState(false);
   const [lastWeight, setLastWeight] = useState(0);
+  const [lastReps, setLastReps] = useState(0);
   const [showAISuggestion, setShowAISuggestion] = useState(false);
   const [aiSuggestion, setAiSuggestion] = useState<string>('');
   const [workoutExerciseId, setWorkoutExerciseId] = useState<string | null>(null);
@@ -59,9 +60,27 @@ export function ExerciseTracker({
         }
       }
     };
-    
+
     fetchWorkoutExerciseId();
   }, [workoutSessionId, exercise.name, exercise.subExercises]);
+
+  // Fetch last exercise stats
+  useEffect(() => {
+    const fetchLastStats = async () => {
+      if (exercise.subExercises && exercise.subExercises.length > 0) return;
+      try {
+        const stats = await getLastExerciseStats(exercise.name);
+        if (stats) {
+          setLastWeight(stats.weight);
+          setLastReps(stats.reps);
+        }
+      } catch (error) {
+        console.error('Failed to fetch last exercise stats:', error);
+      }
+    };
+
+    fetchLastStats();
+  }, [exercise.name, exercise.subExercises]);
 
   // Generate AI suggestions based on performance
   useEffect(() => {
@@ -267,6 +286,11 @@ export function ExerciseTracker({
                 </span>
               ))}
             </div>
+            {(lastWeight > 0 || lastReps > 0) && (
+              <div className="text-sm text-gray-500 mt-2">
+                Last: {lastWeight}kg × {lastReps} reps
+              </div>
+            )}
           </div>
           <div className="text-right">
             <div className="text-sm text-gray-600 font-medium">Target</div>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+export interface AuthHook {
+  user: any | null;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+export function useAuth(): AuthHook {
+  const [user, setUser] = useState<any | null>(null);
+
+  useEffect(() => {
+    if (!supabase) return;
+
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null);
+    });
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const signIn = async () => {
+    if (!supabase) return;
+    const email = import.meta.env.VITE_DEMO_EMAIL;
+    const password = import.meta.env.VITE_DEMO_PASSWORD;
+    if (!email || !password) return;
+    await supabase.auth.signInWithPassword({ email, password });
+  };
+
+  const signOut = async () => {
+    if (!supabase) return;
+    await supabase.auth.signOut();
+  };
+
+  useEffect(() => {
+    if (!user) {
+      signIn().catch(() => {
+        console.warn('Automatic sign in failed.');
+      });
+    }
+  }, [user]);
+
+  return { user, signIn, signOut };
+}


### PR DESCRIPTION
## Summary
- automatically sign in to Supabase using new `useAuth` hook
- fetch the last completed set for each exercise
- display previous weight and reps in `ExerciseTracker`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d25a8d9e4832ab52169bf7c3a07f9