### PR TITLE
Persist workout progress across refresh

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+export function useLocalStorage<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return defaultValue;
+    try {
+      const stored = localStorage.getItem(key);
+      return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      if (value === null || value === undefined) {
+        localStorage.removeItem(key);
+      } else {
+        localStorage.setItem(key, JSON.stringify(value));
+      }
+    } catch {
+      // ignore write errors
+    }
+  }, [key, value]);
+
+  return [value, setValue] as [T, typeof setValue];
+}


### PR DESCRIPTION
## Summary
- add `useLocalStorage` hook to persist values in localStorage
- persist workout state in `DailyWorkout`
- persist set data in `ExerciseTracker`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_687e96707a88832a82bcea8b871ec0b7